### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/seequent/return-dispatch/security/code-scanning/7](https://github.com/seequent/return-dispatch/security/code-scanning/7)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should limit the `GITHUB_TOKEN` permissions to the minimum required for the jobs. Based on the workflow's operations, the `contents: read` permission is sufficient for most steps, and no write permissions are needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, adding it at the root level is more efficient since all jobs appear to require the same minimal permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
