### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,4 +1,6 @@
 name: action-test
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/seequent/return-dispatch/security/code-scanning/5](https://github.com/seequent/return-dispatch/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow only echoes input values and does not interact with repository contents or other resources, we can set `contents: read` as the minimal permission. This ensures that the workflow has no unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
