### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: "Trivy Scan"
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/seequent/return-dispatch/security/code-scanning/4](https://github.com/seequent/return-dispatch/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the tasks performed in this workflow. This change ensures that the workflow does not inadvertently inherit broader permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
