### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,4 +1,7 @@
 name: Action Test
+permissions:
+  contents: read
+  pull-requests: write
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/seequent/return-dispatch/security/code-scanning/3](https://github.com/seequent/return-dispatch/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations:
- `contents: read` is required for reading repository contents.
- `pull-requests: write` may be required for operations related to pull requests.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `test` job. In this case, adding it at the root level is more concise and ensures consistency across jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
